### PR TITLE
[codex] Update Codex marketplace install docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,13 +83,13 @@ This repository ships one public DAT knowledge base in two first-class formats:
 | Tool | Public artifact | Recommended setup |
 |------|-----------------|-------------------|
 | [Claude Code](https://docs.anthropic.com/en/docs/claude-code) | `.claude-plugin/marketplace.json` + `plugins/mwdat-ios/.claude-plugin/plugin.json` | Add this GitHub repo as a marketplace, then install `mwdat-ios` |
-| Codex | `plugins/mwdat-ios/.codex-plugin/plugin.json` | Install the plugin from a cloned checkout of this repo |
+| Codex | `plugins/mwdat-ios/.codex-plugin/plugin.json` | Add this GitHub repo as a Codex marketplace |
 | [GitHub Copilot](https://github.com/features/copilot) | `.github/copilot-instructions.md` | Auto-loaded by Copilot in VS Code |
 | [Cursor](https://cursor.sh/) | `.cursor/rules/*.mdc` | Auto-loaded with glob-based triggers |
 | AGENTS.md-compatible tools | `AGENTS.md` | Portable fallback for agents that read `AGENTS.md` |
 | MCP-compatible editors | `https://mcp.facebook.com/wearables_dat` | Connect as a remote HTTP MCP server |
 
-Claude and Codex install from the plugin payload under `plugins/`. Copilot, Cursor, and `AGENTS.md` readers use the native file-based artifacts at repo root.
+Claude installs from the plugin payload under `plugins/`. Codex adds this repository as a plugin marketplace. Copilot, Cursor, and `AGENTS.md` readers use the native file-based artifacts at repo root.
 
 ### Claude Code
 
@@ -109,7 +109,7 @@ Or use the helper script:
 ```bash
 git clone https://github.com/facebook/meta-wearables-dat-ios.git
 cd meta-wearables-dat-ios
-codex plugin install ./plugins/mwdat-ios
+codex plugin marketplace add .
 ```
 
 Or use the helper script:

--- a/install-skills.sh
+++ b/install-skills.sh
@@ -66,14 +66,14 @@ install_claude() {
 }
 
 install_codex() {
-  echo "Installing Codex plugin for iOS..."
+  echo "Adding Codex marketplace for iOS..."
   require_command codex
   download_archive
-  if [ -d "${PLUGIN_DIR}" ]; then
-    codex plugin install "${PLUGIN_DIR}" || return 1
-    echo "Installed Codex plugin from ${PLUGIN_DIR}."
+  if [ -d "${EXTRACT_DIR}" ]; then
+    codex plugin marketplace add "./${EXTRACT_DIR}" || return 1
+    echo "Added Codex marketplace from ./${EXTRACT_DIR}."
   else
-    echo "Error: Failed to download Codex plugin payload." >&2
+    echo "Error: Failed to download Codex marketplace payload." >&2
     return 1
   fi
 }
@@ -126,7 +126,7 @@ install_all() {
   if command -v codex >/dev/null 2>&1; then
     install_codex || failed=1
   else
-    echo "Skipping Codex plugin install because 'codex' is not on PATH."
+    echo "Skipping Codex marketplace install because 'codex' is not on PATH."
   fi
   install_copilot || failed=1
   install_cursor || failed=1


### PR DESCRIPTION
## What changed

- replaced the deprecated `codex plugin install ./plugins/mwdat-ios` README example with `codex plugin marketplace add .`
- updated the Codex helper path in `install-skills.sh` to use `codex plugin marketplace add`
- fixed the helper script to pass the downloaded repo as `./meta-wearables-dat-ios-main`, which Codex accepts as a local marketplace path
- adjusted surrounding wording so Codex is described as adding the repository as a marketplace rather than installing directly from the plugin subdirectory

## Why

Current Codex CLI no longer exposes `codex plugin install`, so the documented command is stale.

The helper script had the same problem and also needed an explicit `./` prefix for the extracted local directory when calling `codex plugin marketplace add`.

## Impact

Users following the Codex setup instructions can now use the current CLI flow successfully from either:

- the repo root: `codex plugin marketplace add .`
- the helper script: `./install-skills.sh codex`

## Validation

- `bash -n install-skills.sh`
- `env HOME="$(mktemp -d)" codex plugin marketplace add .`
- `env HOME="$(mktemp -d)" ./install-skills.sh codex`

No `package.json` or `pytest` setup is present in this repository, so there was no repo-native `npm test`, `npm run lint`, or `pytest` target to run.
