### PR TITLE
docs: drop stale `await` from MockDevice lifecycle examples

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -562,14 +562,14 @@ let mockDevice = mockDeviceKit.pairRaybanMeta()
 
 ```swift
 // Simulate glasses lifecycle
-await mockDevice.powerOn()
-await mockDevice.unfold()
-await mockDevice.don()    // Simulate wearing the glasses
+mockDevice.powerOn()
+mockDevice.unfold()
+mockDevice.don()    // Simulate wearing the glasses
 
 // Later...
-await mockDevice.doff()   // Simulate removing
-await mockDevice.fold()
-await mockDevice.powerOff()
+mockDevice.doff()   // Simulate removing
+mockDevice.fold()
+mockDevice.powerOff()
 ```
 
 ## Configuring permissions

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -317,14 +317,14 @@ let mockDevice = mockDeviceKit.pairRaybanMeta()
 
 ```swift
 // Simulate glasses lifecycle
-await mockDevice.powerOn()
-await mockDevice.unfold()
-await mockDevice.don()    // Simulate wearing the glasses
+mockDevice.powerOn()
+mockDevice.unfold()
+mockDevice.don()    // Simulate wearing the glasses
 
 // Later...
-await mockDevice.doff()   // Simulate removing
-await mockDevice.fold()
-await mockDevice.powerOff()
+mockDevice.doff()   // Simulate removing
+mockDevice.fold()
+mockDevice.powerOff()
 ```
 
 ## Configuring permissions


### PR DESCRIPTION
## Inconsistency

Four files give Copilot/Cursor/Codex/SKILL-style guidance on `MockDevice` lifecycle methods (`powerOn`, `unfold`, `don`, `doff`, `fold`, `powerOff`) — and they disagree on whether the calls are async:

| File | Style |
|---|---|
| `.cursor/rules/mockdevice-testing.mdc` (lines 38–45) | sync |
| `plugins/mwdat-ios/skills/mockdevice-testing/SKILL.md` (lines 38–45) | sync |
| `.github/copilot-instructions.md` (lines 565–572) | **`await`** ← outlier |
| `AGENTS.md` (lines 320–327) | **`await`** ← outlier |

The SDK API is sync today: [`CameraAccessTests.swift:36`](https://github.com/facebook/meta-wearables-dat-ios/blob/a739e94181221e7f321304273bcda2272821b163/samples/CameraAccess/CameraAccessTests/CameraAccessTests.swift#L36) calls `pairedMockDevice.powerOn()` synchronously and the test compiles and runs in CI.

History suggests this is a docs-sync miss, not an intentional difference:

- **v0.5.0**: all four guidance files used `await`
- **v0.6.0**: the CameraAccess sample appeared with sync calls — the SDK API change happened here
- **v0.7.0**: `.cursor/rules/mockdevice-testing.mdc` was updated to sync; `.github/copilot-instructions.md` and `AGENTS.md` are still stale

## Change

Remove the stale `await` from the six lifecycle calls in each of:

- `.github/copilot-instructions.md` (lines 565–572)
- `AGENTS.md` (lines 320–327)

so all four guidance files agree.

## Open question — should these methods actually be async?

[`CameraAccessTests.swift:36-41`](https://github.com/facebook/meta-wearables-dat-ios/blob/a739e94181221e7f321304273bcda2272821b163/samples/CameraAccess/CameraAccessTests/CameraAccessTests.swift#L36-L41) looks like this:

```swift
pairedMockDevice.powerOn()
pairedMockDevice.unfold()

// Wait for device to be available in Wearables
try await Task.sleep(nanoseconds: 1_000_000_000)
```

The hard-coded 1-second sleep suggests the lifecycle methods return synchronously but the underlying state propagates asynchronously to `Wearables`. This is the kind of synchronization detail an `async` API would express cleanly, and it would also match the original (v0.5.0) `await` form of these examples.

If the team would prefer to move the SDK API in the `async` direction instead, I'd be happy to flip this PR to update `.cursor/rules/mockdevice-testing.mdc`, the SKILL, and the sample to use `await` and drop the manual sleep. Let me know which direction you'd like.

Thank you for  @syarasyoujyu , he founded the following bug.